### PR TITLE
Add delete_manifest test and fix unique_id handling

### DIFF
--- a/src/aws_rag_quickstart/fast_api_wrapper.py
+++ b/src/aws_rag_quickstart/fast_api_wrapper.py
@@ -111,6 +111,6 @@ async def delete_manifest(
     data = json.load(file.file)
     files = [row["name"] for row in data]
     for file_id in files:
-        this = FileEvent(file_path=file_id)
+        this = FileEvent(file_path=file_id, unique_id=file.filename)
         background_tasks.add_task(delete_doc, this.model_dump())
     return {"unique_id": file.filename}


### PR DESCRIPTION
## Summary
- upgrade FastAPI to pydantic v2 compatible version for testing
- ensure `delete_manifest` passes manifest filename as `unique_id`
- test `delete_manifest` to verify `BackgroundTasks` gets queued
- patch `agent_main` test to avoid network access

## Testing
- `PYTHONPATH=./src pytest tests/unit_tests.py::test_delete_manifest -q`
- `PYTHONPATH=./src pytest tests/unit_tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684cbe5442688320974c3e918f82424e